### PR TITLE
Fixed zobrist hash bug where invalid ep squares changed the position

### DIFF
--- a/LinuxMF
+++ b/LinuxMF
@@ -1,6 +1,7 @@
 CC=gcc
 
 SRC=src
+BENCH=bench
 BITBOARDS=$(SRC)/bitboards
 ENDINGS=$(SRC)/endings
 ENGINE=$(SRC)/engine
@@ -17,6 +18,9 @@ ZOBRIST=$(SRC)/zobrist
 TDD_ROOT=tdd
 TDD=$(TDD_ROOT)/tests
 ENGINE_TDD=$(TDD_ROOT)/engine_tests
+
+MAIN=main
+TDD_MAIN=$(TDD_ROOT)/main_tdd
 
 INCDIRS:= \
 -I . \
@@ -84,11 +88,9 @@ $(MOVEGEN)/pieces.o \
 $(UCI)/UCI.o \
 $(ZOBRIST)/zobrist.o
 
-MAIN=main
-CFILES=$(MAIN).c $(COMMON_CFILES)
-OBJECTS=$(MAIN).o $(COMMON_OBJECTS)
+CFILES=$(MAIN).c $(BENCH).c $(COMMON_CFILES)
+OBJECTS=$(MAIN).o $(BENCH).o $(COMMON_OBJECTS)
 
-TDD_MAIN=$(TDD_ROOT)/main_tdd
 
 D_CFILES= \
 $(TDD_MAIN).c \
@@ -134,22 +136,22 @@ $(TDD)/endings_tdd.o \
 $(ENGINE_TDD)/basic_tests.o \
 $(ENGINE_TDD)/PV_table_tdd.o
 
-BINARY=bin
-DEBUG_BINARY=debug
+EXE=bin
+DEBUG_EXE=debug
 
-all: $(BINARY) $(DEBUG_BINARY)
+all: $(EXE) $(DEBUG_EXE)
 
-test: $(DEBUG_BINARY)
-	$(DEBUG_BINARY).exe
+test: $(DEBUG_EXE)
+	$(DEBUG_EXE).exe
 
-$(BINARY): $(OBJECTS)
+$(EXE): $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $^
 
-$(DEBUG_BINARY): $(D_OBJECTS)
+$(DEBUG_EXE): $(D_OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $^
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $^
 
 clean:
-	rm -rf $(BINARY) $(DEBUG_BINARY) *.o && clear
+	rm -rf $(EXE) $(DEBUG_EXE) *.o

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ INCDIRS:= \
 
 DEBUGFLAGS=-g
 OPTFLAGS=-O3 -flto
-CFLAGS=-Wall -std=c17 -march=native $(DEBUGFLAGS) $(INCDIRS) 
+CFLAGS=-Wall -std=c17 -march=native $(OPTFLAGS) $(INCDIRS) 
 
 COMMON_CFILES= \
 $(BITBOARDS)\bitboards.c \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ INCDIRS:= \
 
 DEBUGFLAGS=-g
 OPTFLAGS=-O3 -flto
-CFLAGS=-Wall -std=c17 -march=native $(OPTFLAGS) $(INCDIRS) 
+CFLAGS=-Wall -std=c17 -march=native $(DEBUGFLAGS) $(INCDIRS) 
 
 COMMON_CFILES= \
 $(BITBOARDS)\bitboards.c \

--- a/src/FEN/FEN.c
+++ b/src/FEN/FEN.c
@@ -73,7 +73,7 @@ static void UpdateEnPassant(FEN_t fen, int* i, GameState_t* state) {
     if(fen[*i] == '-') {
         (*i)++;
     } else {
-        state->enPassantSquares = SquareCharsToBitboard(fen[*i], fen[*i + 1]);
+        state->enPassantSquare = SquareCharsToBitboard(fen[*i], fen[*i + 1]);
         (*i) += 2;
     }
 }

--- a/src/FEN/FEN.c
+++ b/src/FEN/FEN.c
@@ -79,9 +79,7 @@ static void UpdateEnPassant(FEN_t fen, int* i, GameState_t* state, Color_t color
 
         if(eastPawn) {
             state->canEastEP = true;
-            state->canWestEP = false;
         } else {
-            state->canEastEP = false;
             state->canWestEP = true;
         }
 

--- a/src/FEN/FEN.c
+++ b/src/FEN/FEN.c
@@ -2,7 +2,6 @@
 #include <assert.h>
 
 #include "FEN.h"
-#include "board_constants.h"
 
 static double usr_pow(int x, int y) {
     double result = 1;
@@ -69,11 +68,23 @@ static Bitboard_t SquareCharsToBitboard(char col, char row) {
     return CalculateSingleBitset(square);
 }
 
-static void UpdateEnPassant(FEN_t fen, int* i, GameState_t* state) {
+// will break if double en passant is possible. Ultra edge case and I am lazy.
+static void UpdateEnPassant(FEN_t fen, int* i, GameState_t* state, Color_t color) { 
     if(fen[*i] == '-') {
         (*i)++;
     } else {
         state->enPassantSquare = SquareCharsToBitboard(fen[*i], fen[*i + 1]);
+        
+        Bitboard_t eastPawn = (color == white) ? SoWeOne(state->enPassantSquare) : NoWeOne(state->enPassantSquare);
+
+        if(eastPawn) {
+            state->canEastEP = true;
+            state->canWestEP = false;
+        } else {
+            state->canEastEP = false;
+            state->canWestEP = true;
+        }
+
         (*i) += 2;
     }
 }
@@ -207,7 +218,7 @@ void InterpretFEN(
     }
 
     i++;
-    UpdateEnPassant(fen, &i, gameState);
+    UpdateEnPassant(fen, &i, gameState, info->colorToMove);
 
     i++;
     UpdateHalfmoveClock(fen, i, gameState);

--- a/src/UCI/UCI.c
+++ b/src/UCI/UCI.c
@@ -403,7 +403,14 @@ bool InterpretUCIInput(UciApplicationData_t* applicationData)
     return true; // true means application keeps running
 }
 
-void InterpretUCIString(UciApplicationData_t* applicationData, const char* _input) {
+void InterpretUCIString(
+    BoardInfo_t* boardInfo,
+    GameStack_t* gameStack,
+    ZobristStack_t* zobristStack,
+    const char* _input
+)
+{
+    UciApplicationData_t data;
     char input[BUFFER_SIZE];
     memset(input, '\0', BUFFER_SIZE* sizeof(char));
     memcpy(input, _input, strlen(_input));
@@ -417,11 +424,15 @@ void InterpretUCIString(UciApplicationData_t* applicationData, const char* _inpu
 
         SkipToNextCharacter(input, &i);
 
-        bool keepRunning = RespondToSignal(input, &i, signal, applicationData);
+        bool keepRunning = RespondToSignal(input, &i, signal, &data);
         if(!keepRunning) {
             return; 
         }
     }
+
+    *boardInfo = data.boardInfo;
+    *gameStack = data.gameStack;
+    *zobristStack = data.zobristStack;
 }
 
 void SendPvInfo(PvTable_t* pvTable, Depth_t depth) {

--- a/src/UCI/UCI.c
+++ b/src/UCI/UCI.c
@@ -403,6 +403,27 @@ bool InterpretUCIInput(UciApplicationData_t* applicationData)
     return true; // true means application keeps running
 }
 
+void InterpretUCIString(UciApplicationData_t* applicationData, const char* _input) {
+    char input[BUFFER_SIZE];
+    memset(input, '\0', BUFFER_SIZE* sizeof(char));
+    memcpy(input, _input, strlen(_input));
+
+    char currentWord[BUFFER_SIZE];
+
+    int i = 0;
+    while(i < BUFFER_SIZE && input[i] != '\0') {
+        GetNextWord(input, currentWord, &i);
+        UciSignal_t signal = InterpretWord(currentWord);
+
+        SkipToNextCharacter(input, &i);
+
+        bool keepRunning = RespondToSignal(input, &i, signal, applicationData);
+        if(!keepRunning) {
+            return; 
+        }
+    }
+}
+
 void SendPvInfo(PvTable_t* pvTable, Depth_t depth) {
     PvLength_t variationLength = pvTable->pvLength[0];
     printf("info depth %d pv", depth);

--- a/src/UCI/UCI.h
+++ b/src/UCI/UCI.h
@@ -22,6 +22,8 @@ bool UCITranslateMove(Move_t* move, const char* moveText, BoardInfo_t* boardInfo
 
 bool InterpretUCIInput(UciApplicationData_t* applicationData);
 
+void InterpretUCIString(UciApplicationData_t* applicationData, const char* _input);
+
 void SendPvInfo(PvTable_t* pvTable, Depth_t depth);
 
 #define SendUciInfoString(formatString, ...) \

--- a/src/UCI/UCI.h
+++ b/src/UCI/UCI.h
@@ -22,7 +22,12 @@ bool UCITranslateMove(Move_t* move, const char* moveText, BoardInfo_t* boardInfo
 
 bool InterpretUCIInput(UciApplicationData_t* applicationData);
 
-void InterpretUCIString(UciApplicationData_t* applicationData, const char* _input);
+void InterpretUCIString(
+    BoardInfo_t* boardInfo,
+    GameStack_t* gameStack,
+    ZobristStack_t* zobristStack,
+    const char* _input
+);
 
 void SendPvInfo(PvTable_t* pvTable, Depth_t depth);
 

--- a/src/bitboards/bitboards.c
+++ b/src/bitboards/bitboards.c
@@ -38,9 +38,6 @@ Population_t PopCount(Bitboard_t mask)
 }
 
 Square_t LSB(Bitboard_t b) { // I hate macros and you can't force me to use them
-    if(!b) {
-        assert(b);
-    }
     assert(b);
     return __builtin_ctzll(b);
 }

--- a/src/bitboards/bitboards.c
+++ b/src/bitboards/bitboards.c
@@ -38,6 +38,9 @@ Population_t PopCount(Bitboard_t mask)
 }
 
 Square_t LSB(Bitboard_t b) { // I hate macros and you can't force me to use them
+    if(!b) {
+        assert(b);
+    }
     assert(b);
     return __builtin_ctzll(b);
 }

--- a/src/bitboards/bitboards.c
+++ b/src/bitboards/bitboards.c
@@ -37,7 +37,7 @@ Population_t PopCount(Bitboard_t mask)
 #endif
 }
 
-Square_t LSB(Bitboard_t b) { // I hate macros and you can't force me to use them
+Square_t LSB(Bitboard_t b) {
     assert(b);
     return __builtin_ctzll(b);
 }

--- a/src/movegen/movegen.c
+++ b/src/movegen/movegen.c
@@ -193,7 +193,7 @@ static void AddHvSliderMoves(
     });
 }
 
-static bool EnPassantIsLegal(BoardInfo_t* boardInfo, Bitboard_t toBB, Bitboard_t fromBB, Color_t color) {
+bool EnPassantIsLegal(BoardInfo_t* boardInfo, Bitboard_t toBB, Bitboard_t fromBB, Color_t color) {
     Bitboard_t captureBB = (color == white) ? SoutOne(toBB) : NortOne(toBB);
 
     ResetBits(&boardInfo->pawns[color], fromBB);
@@ -216,7 +216,7 @@ static bool EnPassantIsLegal(BoardInfo_t* boardInfo, Bitboard_t toBB, Bitboard_t
     return isLegal;
 }
 
-static void TryEnPassant(
+static void AddEnPassantMove(
     MoveList_t* moveList,
     BoardInfo_t* boardInfo,
     Bitboard_t toBB,
@@ -224,14 +224,12 @@ static void TryEnPassant(
     Color_t color
 )
 {
-    if(EnPassantIsLegal(boardInfo, toBB, fromBB, color)) {
-        InitializeNewMove(moveList);
-        Move_t* current = CurrentMove(moveList);
+    InitializeNewMove(moveList);
+    Move_t* current = CurrentMove(moveList);
 
-        WriteToSquare(current, LSB(toBB));
-        WriteFromSquare(current, LSB(fromBB));
-        WriteSpecialFlag(current, en_passant_flag);
-    }
+    WriteToSquare(current, LSB(toBB));
+    WriteFromSquare(current, LSB(fromBB));
+    WriteSpecialFlag(current, en_passant_flag);
 }
 
 static void AddWhiteLegalEnPassant(
@@ -252,7 +250,7 @@ static void AddWhiteLegalEnPassant(
         (WhiteWestEnPassantTargets(d12PinnedPawns, enPassantBB) & pinmasks.d12);
 
     if(eastLegalEnPassantTargets) {
-        TryEnPassant(
+        AddEnPassantMove(
             moveList,
             boardInfo,
             eastLegalEnPassantTargets,
@@ -262,7 +260,7 @@ static void AddWhiteLegalEnPassant(
     }
 
     if(westLegalEnPassantTargets) {
-        TryEnPassant(
+        AddEnPassantMove(
             moveList,
             boardInfo,
             westLegalEnPassantTargets,
@@ -290,7 +288,7 @@ static void AddBlackLegalEnPassant(
         (BlackWestEnPassantTargets(d12PinnedPawns, enPassantBB) & pinmasks.d12);
 
     if(eastLegalEnPassantTargets) {
-        TryEnPassant(
+        AddEnPassantMove(
             moveList,
             boardInfo,
             eastLegalEnPassantTargets,
@@ -300,7 +298,7 @@ static void AddBlackLegalEnPassant(
     }
 
     if(westLegalEnPassantTargets) {
-        TryEnPassant(
+        AddEnPassantMove(
             moveList,
             boardInfo,
             westLegalEnPassantTargets,

--- a/src/movegen/movegen.c
+++ b/src/movegen/movegen.c
@@ -194,7 +194,7 @@ static void AddHvSliderMoves(
 }
 
 static bool EnPassantIsLegal(BoardInfo_t* boardInfo, Bitboard_t toBB, Bitboard_t fromBB, Color_t color) {
-    Bitboard_t captureBB = (color == white) ? SoutOne(toBB) : NortOne(toBB);;
+    Bitboard_t captureBB = (color == white) ? SoutOne(toBB) : NortOne(toBB);
 
     ResetBits(&boardInfo->pawns[color], fromBB);
     SetBits(&boardInfo->pawns[color], toBB);
@@ -203,7 +203,7 @@ static bool EnPassantIsLegal(BoardInfo_t* boardInfo, Bitboard_t toBB, Bitboard_t
     SetBits(&boardInfo->empty, fromBB|captureBB);
     ResetBits(&boardInfo->empty, toBB);
 
-    Bitboard_t unsafeSquares = UnsafeSquares(boardInfo, white);
+    Bitboard_t unsafeSquares = UnsafeSquares(boardInfo, color);
     bool isLegal = !InCheck(boardInfo->kings[color], unsafeSquares);
 
     SetBits(&boardInfo->pawns[color], fromBB);

--- a/src/movegen/movegen.h
+++ b/src/movegen/movegen.h
@@ -18,4 +18,6 @@ typedef struct {
 
 void CompleteMovegen(MoveList_t* moveList, BoardInfo_t* boardInfo, GameStack_t* stack);
 
+bool EnPassantIsLegal(BoardInfo_t* boardInfo, Bitboard_t toBB, Bitboard_t fromBB, Color_t color);
+
 #endif

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -217,7 +217,7 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
         UpdateCastleSquares(nextState, boardInfo, !color); // if we captured, we might have messed up our opponent's castling rights
     }
 
-    bool pawnDoublePushed;
+    bool pawnDoublePushed = false;
     Piece_t type = PieceOnSquare(boardInfo, fromSquare);
     switch (type) {
         case pawn:

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -11,8 +11,10 @@ enum {
     rook_start_squares = board_corners
 };
 
-static bool PawnIsDoublePushed(Bitboard_t fromBB, Bitboard_t toBB) {
-    return (fromBB & pawn_start_ranks) && (toBB & pawn_double_ranks);
+static bool PsuedovalidEPSquare(Bitboard_t fromBB, Bitboard_t toBB, Bitboard_t enemyPawns) {
+    bool isDoublePush = (fromBB & pawn_start_ranks) && (toBB & pawn_double_ranks);
+    bool enemyPawnNeighbors = (EastOne(toBB) | WestOne(toBB)) & enemyPawns;
+    return isDoublePush && enemyPawnNeighbors;
 }
 
 static void UpdateCastleSquares(GameState_t* nextState, BoardInfo_t* info, Color_t color) {
@@ -211,7 +213,7 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
         case pawn:
             nextState->halfmoveClock = 0;
 
-            if(PawnIsDoublePushed(fromBB, toBB)) {
+            if(PsuedovalidEPSquare(fromBB, toBB, boardInfo->pawns[!color])) { // psuedovalid good enough for now in zobrist hashes
                 nextState->enPassantSquares = GetEnPassantBB(toBB, color);
             }
         break;

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -11,10 +11,8 @@ enum {
     rook_start_squares = board_corners
 };
 
-static bool PsuedovalidEPSquare(Bitboard_t fromBB, Bitboard_t toBB, Bitboard_t enemyPawns) {
-    bool isDoublePush = (fromBB & pawn_start_ranks) && (toBB & pawn_double_ranks);
-    bool enemyPawnNeighbors = (EastOne(toBB) | WestOne(toBB)) & enemyPawns;
-    return isDoublePush && enemyPawnNeighbors;
+static bool PawnIsDoublePushed(Bitboard_t fromBB, Bitboard_t toBB) {
+    return (fromBB & pawn_start_ranks) && (toBB & pawn_double_ranks);
 }
 
 static void UpdateCastleSquares(GameState_t* nextState, BoardInfo_t* info, Color_t color) {
@@ -213,7 +211,7 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
         case pawn:
             nextState->halfmoveClock = 0;
 
-            if(PsuedovalidEPSquare(fromBB, toBB, boardInfo->pawns[!color])) { // psuedovalid good enough for now in zobrist hashes
+            if(PawnIsDoublePushed(fromBB, toBB)) {
                 nextState->enPassantSquares = GetEnPassantBB(toBB, color);
             }
         break;

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -181,7 +181,7 @@ static void MakeEnPassantHandler(BoardInfo_t* boardInfo, GameState_t* nextState,
     );
 
     nextState->halfmoveClock = empty_set;
-    nextState->enPassantSquares = empty_set;
+    nextState->enPassantSquare = empty_set;
     nextState->capturedPiece = pawn;
 }
 
@@ -212,7 +212,7 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
             nextState->halfmoveClock = 0;
 
             if(PawnIsDoublePushed(fromBB, toBB)) {
-                nextState->enPassantSquares = GetEnPassantBB(toBB, color);
+                nextState->enPassantSquare = GetEnPassantBB(toBB, color);
             }
         break;
         case king:

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 
 #include "make_and_unmake.h"
+#include "movegen.h"
 #include "game_state.h"
 #include "lookup.h"
 
@@ -13,6 +14,16 @@ enum {
 
 static bool PawnIsDoublePushed(Bitboard_t fromBB, Bitboard_t toBB) {
     return (fromBB & pawn_start_ranks) && (toBB & pawn_double_ranks);
+}
+
+static void UpdateEnPassantInfo(BoardInfo_t* info, GameState_t* nextState, Bitboard_t fromBB, Bitboard_t toBB, Color_t color) {
+    Bitboard_t eastAdjPawn = info->pawns[!color] & EastOne(toBB);
+    Bitboard_t westAdjPawn = info->pawns[!color] & WestOne(toBB);
+    Bitboard_t enPassantSquare = GetEnPassantBB(toBB, color);
+
+    nextState->canEastEP = eastAdjPawn && EnPassantIsLegal(info, enPassantSquare, eastAdjPawn, color);
+    nextState->canWestEP = westAdjPawn && EnPassantIsLegal(info, enPassantSquare, westAdjPawn, color);
+    nextState->enPassantSquare = enPassantSquare;
 }
 
 static void UpdateCastleSquares(GameState_t* nextState, BoardInfo_t* info, Color_t color) {
@@ -212,7 +223,7 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
             nextState->halfmoveClock = 0;
 
             if(PawnIsDoublePushed(fromBB, toBB)) {
-                nextState->enPassantSquare = GetEnPassantBB(toBB, color);
+                
             }
         break;
         case king:

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -29,8 +29,8 @@ static void UpdateEnPassantInfo(BoardInfo_t* info, GameState_t* nextState, Bitbo
     Bitboard_t westAdjPawn = info->pawns[!color] & WestOne(toBB);
     Bitboard_t enPassantSquare = GetEnPassantBB(toBB, color);
 
-    nextState->canEastEP = eastAdjPawn && EnPassantIsLegal(info, enPassantSquare, eastAdjPawn, color);
-    nextState->canWestEP = westAdjPawn && EnPassantIsLegal(info, enPassantSquare, westAdjPawn, color);
+    nextState->canWestEP = eastAdjPawn && EnPassantIsLegal(info, enPassantSquare, eastAdjPawn, !color);
+    nextState->canEastEP = westAdjPawn && EnPassantIsLegal(info, enPassantSquare, westAdjPawn, !color);
     nextState->enPassantSquare = enPassantSquare;
 }
 
@@ -217,13 +217,12 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
         UpdateCastleSquares(nextState, boardInfo, !color); // if we captured, we might have messed up our opponent's castling rights
     }
 
+    bool pawnDoublePushed;
     Piece_t type = PieceOnSquare(boardInfo, fromSquare);
     switch (type) {
         case pawn:
             nextState->halfmoveClock = 0;
-            if(PawnIsDoublePushed(fromBB, toBB)) {
-                UpdateEnPassantInfo(boardInfo, nextState, fromBB, toBB, color);
-            }
+            pawnDoublePushed = PawnIsDoublePushed(fromBB, toBB);
         break;
         case king:
             nextState->castleSquares[color] = empty_set;
@@ -241,6 +240,10 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
     );
 
     UpdateCastleSquares(nextState, boardInfo, color);
+
+    if(pawnDoublePushed) {
+        UpdateEnPassantInfo(boardInfo, nextState, fromBB, toBB, color);
+    }
 }
 
 void MakeMove(BoardInfo_t* boardInfo, GameStack_t* gameStack, Move_t move) {

--- a/src/play/make_and_unmake.c
+++ b/src/play/make_and_unmake.c
@@ -16,6 +16,14 @@ static bool PawnIsDoublePushed(Bitboard_t fromBB, Bitboard_t toBB) {
     return (fromBB & pawn_start_ranks) && (toBB & pawn_double_ranks);
 }
 
+static Bitboard_t GetEnPassantBB(Bitboard_t toBB, Color_t color) {
+    if(color == white) {
+        return SoutOne(toBB);
+    } else {
+        return NortOne(toBB);
+    }
+}
+
 static void UpdateEnPassantInfo(BoardInfo_t* info, GameState_t* nextState, Bitboard_t fromBB, Bitboard_t toBB, Color_t color) {
     Bitboard_t eastAdjPawn = info->pawns[!color] & EastOne(toBB);
     Bitboard_t westAdjPawn = info->pawns[!color] & WestOne(toBB);
@@ -159,14 +167,6 @@ static void MakePromotionHandler(BoardInfo_t* boardInfo, GameState_t* nextState,
     nextState->halfmoveClock = empty_set;
 }
 
-static Bitboard_t GetEnPassantBB(Bitboard_t toBB, Color_t color) {
-    if(color == white) {
-        return SoutOne(toBB);
-    } else {
-        return NortOne(toBB);
-    }
-}
-
 static void MakeEnPassantHandler(BoardInfo_t* boardInfo, GameState_t* nextState, Move_t move) {
     Color_t color = boardInfo->colorToMove;
     Square_t fromSquare = ReadFromSquare(move);
@@ -221,9 +221,8 @@ static void MakeMoveDefaultHandler(BoardInfo_t* boardInfo, GameState_t* nextStat
     switch (type) {
         case pawn:
             nextState->halfmoveClock = 0;
-
             if(PawnIsDoublePushed(fromBB, toBB)) {
-                
+                UpdateEnPassantInfo(boardInfo, nextState, fromBB, toBB, color);
             }
         break;
         case king:

--- a/src/state/game_state.c
+++ b/src/state/game_state.c
@@ -38,6 +38,8 @@ GameState_t* GetDefaultNextGameState(GameStack_t* stack) {
     defaultState->castleSquares[white] = ReadCastleSquares(stack, white);
     defaultState->castleSquares[black] = ReadCastleSquares(stack, black);
     defaultState->enPassantSquare = empty_set;
+    defaultState->canEastEP = false;
+    defaultState->canWestEP = false;
 
     stack->top++;
     return defaultState;

--- a/src/state/game_state.c
+++ b/src/state/game_state.c
@@ -24,6 +24,8 @@ GameState_t* GetEmptyNextGameState(GameStack_t* stack) {
     nextState->castleSquares[white] = empty_set;
     nextState->castleSquares[black] = empty_set;
     nextState->enPassantSquare = empty_set;
+    nextState->canEastEP = false;
+    nextState->canWestEP = false;
     InitBoardInfo(&nextState->boardInfo);
 
     stack->top++;

--- a/src/state/game_state.c
+++ b/src/state/game_state.c
@@ -23,7 +23,7 @@ GameState_t* GetEmptyNextGameState(GameStack_t* stack) {
     nextState->halfmoveClock = 0;
     nextState->castleSquares[white] = empty_set;
     nextState->castleSquares[black] = empty_set;
-    nextState->enPassantSquares = empty_set;
+    nextState->enPassantSquare = empty_set;
     InitBoardInfo(&nextState->boardInfo);
 
     stack->top++;
@@ -37,7 +37,7 @@ GameState_t* GetDefaultNextGameState(GameStack_t* stack) {
     defaultState->halfmoveClock = ReadHalfmoveClock(stack) + 1;
     defaultState->castleSquares[white] = ReadCastleSquares(stack, white);
     defaultState->castleSquares[black] = ReadCastleSquares(stack, black);
-    defaultState->enPassantSquares = empty_set;
+    defaultState->enPassantSquare = empty_set;
 
     stack->top++;
     return defaultState;
@@ -68,7 +68,15 @@ Bitboard_t ReadCastleSquares(GameStack_t* stack, Color_t color) {
 }
 
 Bitboard_t ReadEnPassant(GameStack_t* stack) {
-    return CurrentState(stack).enPassantSquares;
+    return CurrentState(stack).enPassantSquare;
+}
+
+bool CanWestEnPassant(GameStack_t* stack) {
+    return CurrentState(stack).canWestEP;
+}
+
+bool CanEastEnPassant(GameStack_t* stack) {
+    return CurrentState(stack).canEastEP;
 }
 
 BoardInfo_t ReadCurrentBoardInfo(GameStack_t* stack) {

--- a/src/state/game_state.h
+++ b/src/state/game_state.h
@@ -8,8 +8,10 @@
 typedef uint16_t HalfmoveCount_t;
 typedef struct {
     Piece_t capturedPiece;
+    bool canEastEP;
+    bool canWestEP;
     HalfmoveCount_t halfmoveClock;
-    Bitboard_t enPassantSquares;
+    Bitboard_t enPassantSquare;
     Bitboard_t castleSquares[2];
     BoardInfo_t boardInfo;
 } GameState_t;
@@ -36,6 +38,10 @@ HalfmoveCount_t ReadHalfmoveClock(GameStack_t* stack);
 Bitboard_t ReadCastleSquares(GameStack_t* stack, Color_t color);
 
 Bitboard_t ReadEnPassant(GameStack_t* stack);
+
+bool CanWestEnPassant(GameStack_t* stack);
+
+bool CanEastEnPassant(GameStack_t* stack);
 
 BoardInfo_t ReadCurrentBoardInfo(GameStack_t* stack);
 

--- a/src/util_macros.h
+++ b/src/util_macros.h
@@ -3,4 +3,6 @@
 
 #define NUM_ARRAY_ELEMENTS(array) sizeof(array) / sizeof(*array)
 
+#define MIRROR(sq) ((sq)^56)
+
 #endif

--- a/src/zobrist/zobrist.c
+++ b/src/zobrist/zobrist.c
@@ -80,7 +80,7 @@ ZobristHash_t HashPosition(BoardInfo_t* boardInfo, GameStack_t* gameStack) {
     UpdateHashWithPieceBitboard(&zobristHash, boardInfo->kings[black], king, blackPieceKeys);
 
     UpdateHashWithCastlingRights(&zobristHash, gameState.castleSquares[white], gameState.castleSquares[black]);
-    UpdateHashEnPassantFile(&zobristHash, gameState.enPassantSquares);
+    UpdateHashEnPassantFile(&zobristHash, gameState.enPassantSquare);
 
     if(boardInfo->colorToMove == black) {
         zobristHash ^= sideToMoveIsBlackKey;

--- a/src/zobrist/zobrist.c
+++ b/src/zobrist/zobrist.c
@@ -55,10 +55,8 @@ static void UpdateHashWithCastlingRights(ZobristHash_t* zobristHash, Bitboard_t 
     *zobristHash ^= castlingKeys[keyIndex];
 }
 
-static void UpdateHashEnPassantFile(ZobristHash_t* zobristHash, Bitboard_t enPassant) {
-    if(enPassant) {
-        *zobristHash ^= enPassantFileKeys[LSB(enPassant) % 8];
-    }
+static void UpdateHashEnPassantFile(ZobristHash_t* zobristHash, Bitboard_t enPassantBB) {
+    *zobristHash ^= enPassantFileKeys[LSB(enPassantBB) % 8];
 }
 
 ZobristHash_t HashPosition(BoardInfo_t* boardInfo, GameStack_t* gameStack) {
@@ -80,7 +78,10 @@ ZobristHash_t HashPosition(BoardInfo_t* boardInfo, GameStack_t* gameStack) {
     UpdateHashWithPieceBitboard(&zobristHash, boardInfo->kings[black], king, blackPieceKeys);
 
     UpdateHashWithCastlingRights(&zobristHash, gameState.castleSquares[white], gameState.castleSquares[black]);
-    UpdateHashEnPassantFile(&zobristHash, gameState.enPassantSquare);
+
+    if(gameState.canEastEP || gameState.canWestEP) {
+        UpdateHashEnPassantFile(&zobristHash, gameState.enPassantSquare);
+    }
 
     if(boardInfo->colorToMove == black) {
         zobristHash ^= sideToMoveIsBlackKey;

--- a/tdd/debug.c
+++ b/tdd/debug.c
@@ -219,7 +219,7 @@ bool CompareInfo(BoardInfo_t* info, BoardInfo_t* expectedInfo) {
 bool CompareState(GameState_t* expectedState, GameStack_t* stack) {
     return
         (ReadHalfmoveClock(stack) == expectedState->halfmoveClock) &&
-        (ReadEnPassant(stack) == expectedState->enPassantSquares) &&
+        (ReadEnPassant(stack) == expectedState->enPassantSquare) &&
         (ReadCastleSquares(stack, white) == expectedState->castleSquares[white]) &&
         (ReadCastleSquares(stack, black) == expectedState->castleSquares[black]) &&
         (ReadCapturedPiece(stack) == expectedState->capturedPiece);

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     SpeedTest(START_FEN, 6, false);
 
     FEN_t fen = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/Pp2P3/2N2Q1p/1PPBBPPP/R3K2R b KQkq a3 0";
-    PERFTRunner(fen, 1, true);
+    PERFTRunner(fen, 1, false);
     RunAllPerftTests(false);
     
     UciApplicationData_t uciApplicationData;

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     RunAllPerftTests(false);
     
     UciApplicationData_t uciApplicationData;
-    bool running = true;
+    bool running = false;
     while(running)
     {
         running = InterpretUCIInput(&uciApplicationData);

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
 
     FEN_t fen = "rnbqkbnr/pppppp1p/6p1/8/8/3P4/PPP1PPPP/RNBQKBNR w KQkq - 0 2";
     PERFTRunner(fen, 2, false);
-    RunAllPerftTests(true);
+    RunAllPerftTests(false);
     
     UciApplicationData_t uciApplicationData;
     bool running = false;

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -63,8 +63,8 @@ int main(int argc, char** argv)
 
     SpeedTest(START_FEN, 6, false);
 
-    FEN_t fen = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/Pp2P3/2N2Q1p/1PPBBPPP/R3K2R b KQkq a3 0";
-    PERFTRunner(fen, 1, false);
+    FEN_t fen = "rnbqkbnr/pppppp1p/6p1/8/8/3P4/PPP1PPPP/RNBQKBNR w KQkq - 0 2";
+    PERFTRunner(fen, 2, false);
     RunAllPerftTests(true);
     
     UciApplicationData_t uciApplicationData;

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -20,26 +20,12 @@
 #include "basic_tests.h"
 #include "PV_table_tdd.h"
 
-void RandomTest() {
-    const char* uciString = "position fen r7/4n2p/1p4p1/6P1/2k2P2/1q6/7K/8 b - - 25 68 moves h7h5";
-    BoardInfo_t boardInfo;
-    GameStack_t gameStack;
-    ZobristStack_t zobristStack;
-
-    InterpretUCIString(&boardInfo, &gameStack, &zobristStack, uciString);
-
-    MoveList_t moveList;
-    CompleteMovegen(&moveList, &boardInfo, &gameStack);
-}
-
 int main(int argc, char** argv)
 {
     setvbuf(stdout, NULL, _IONBF, 0);
 
     InitLookupTables();
     GenerateZobristKeys();
-    
-    RandomTest();
 
     LookupTDDRunner();
     BitboardsTDDRunner();

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -49,8 +49,8 @@ int main(int argc, char** argv)
 
     SpeedTest(START_FEN, 6, false);
 
-    FEN_t fen = "8/8/8/3p4/4pn1N/6p1/8/5K1k w - - 10 73";
-    PERFTRunner(fen, 8, false);
+    FEN_t fen = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/Pp2P3/2N2Q1p/1PPBBPPP/R3K2R b KQkq a3 0";
+    PERFTRunner(fen, 1, true);
     RunAllPerftTests(false);
     
     UciApplicationData_t uciApplicationData;

--- a/tdd/main_tdd.c
+++ b/tdd/main_tdd.c
@@ -20,6 +20,18 @@
 #include "basic_tests.h"
 #include "PV_table_tdd.h"
 
+void RandomTest() {
+    const char* uciString = "position fen r7/4n2p/1p4p1/6P1/2k2P2/1q6/7K/8 b - - 25 68 moves h7h5";
+    BoardInfo_t boardInfo;
+    GameStack_t gameStack;
+    ZobristStack_t zobristStack;
+
+    InterpretUCIString(&boardInfo, &gameStack, &zobristStack, uciString);
+
+    MoveList_t moveList;
+    CompleteMovegen(&moveList, &boardInfo, &gameStack);
+}
+
 int main(int argc, char** argv)
 {
     setvbuf(stdout, NULL, _IONBF, 0);
@@ -27,6 +39,8 @@ int main(int argc, char** argv)
     InitLookupTables();
     GenerateZobristKeys();
     
+    RandomTest();
+
     LookupTDDRunner();
     BitboardsTDDRunner();
     BoardInfoTDDRunner();
@@ -51,7 +65,7 @@ int main(int argc, char** argv)
 
     FEN_t fen = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/Pp2P3/2N2Q1p/1PPBBPPP/R3K2R b KQkq a3 0";
     PERFTRunner(fen, 1, false);
-    RunAllPerftTests(false);
+    RunAllPerftTests(true);
     
     UciApplicationData_t uciApplicationData;
     bool running = false;

--- a/tdd/tests/FEN_tdd.c
+++ b/tdd/tests/FEN_tdd.c
@@ -58,7 +58,7 @@ static void InitComplexFENExpectedInfo(BoardInfo_t* expectedInfo, GameState_t* e
     GameState_t* state = GetEmptyNextGameState(&gameStack);
     state->halfmoveClock = 34;
     state->castleSquares[white] = white_kingside_castle_bb;
-    state->enPassantSquares = CreateBitboard(1, e3);
+    state->enPassantSquare = CreateBitboard(1, e3);
     *expectedState = *state;
 }
 

--- a/tdd/tests/endings_tdd.c
+++ b/tdd/tests/endings_tdd.c
@@ -145,6 +145,14 @@ static void ShouldNotDrawTwoMinorPieces() {
     PrintResults(GameEndStatusShouldBe(ongoing, some_movelist_max));
 }
 
+static void ShouldFindEndgameThreefold() {
+    const char* uciString = "position fen 3k1b2/3r3p/4p3/2p1Np1p/1p6/7R/2P1KPPP/r7 b - - 1 37 moves d7d1 f2f4 d1c1 e2d2 c1d1 d2e2 d1c1 e2d2 c1d1 d2e2";
+
+    InterpretUCIString(&boardInfo, &gameStack, &zobristStack, uciString);
+
+    PrintResults(GameEndStatusShouldBe(draw, some_movelist_max));
+}
+
 void EndingsTDDRunner() {
     ShouldDrawWhenHalfmoveCountHits100();
     ShouldIdentifyCheckmate();
@@ -157,4 +165,5 @@ void EndingsTDDRunner() {
     ShouldDrawOneSideKnight();
     ShouldDrawOneSideBishop();
     ShouldNotDrawTwoMinorPieces();
+    ShouldFindEndgameThreefold();
 }

--- a/tdd/tests/game_state_tdd.c
+++ b/tdd/tests/game_state_tdd.c
@@ -18,7 +18,7 @@ static bool GameStateIsCorrect(GameStack_t* stack, GameState_t* expected) {
         (ReadHalfmoveClock(stack) == expected->halfmoveClock) &&
         (ReadCastleSquares(stack, white) == expected->castleSquares[white]) &&
         (ReadCastleSquares(stack, black) == expected->castleSquares[black]) &&
-        (ReadEnPassant(stack) == expected->enPassantSquares);
+        (ReadEnPassant(stack) == expected->enPassantSquare);
 }
 
 static GameState_t* GetSomeGamestate(GameStack_t* stack) {
@@ -27,7 +27,7 @@ static GameState_t* GetSomeGamestate(GameStack_t* stack) {
     state->capturedPiece = some_captured_piece;
     state->halfmoveClock = some_halfmove_clock;
     state->castleSquares[white] = some_white_castle_squares;
-    state->enPassantSquares = some_white_enpassant_squares;
+    state->enPassantSquare = some_white_enpassant_squares;
     state->castleSquares[black] = some_black_castle_squares;
 
     return state;
@@ -51,7 +51,7 @@ static void ShouldGetDefaultState() {
         .capturedPiece = none_type,
         .halfmoveClock = state->halfmoveClock + 1,
         .castleSquares = {state->castleSquares[white], state->castleSquares[black]},
-        .enPassantSquares = empty_set
+        .enPassantSquare = empty_set
     };
 
     GetDefaultNextGameState(&stack);

--- a/tdd/tests/legals_tdd.c
+++ b/tdd/tests/legals_tdd.c
@@ -364,9 +364,9 @@ static void ShouldIdentifyIllegalEnPassant() {
     BoardInfo_t info;
     InitEnPassantIllegalPositionInfo(&info);
 
-    Bitboard_t enPassantSquares = CreateBitboard(1, c6);
+    Bitboard_t enPassantSquare = CreateBitboard(1, c6);
 
-    bool success = WestEnPassantIsLegal(&info, SoEaOne(enPassantSquares), white) == 0;
+    bool success = WestEnPassantIsLegal(&info, SoEaOne(enPassantSquare), white) == 0;
 
     PrintResults(success);
 }

--- a/tdd/tests/make_and_unmake_tdd.c
+++ b/tdd/tests/make_and_unmake_tdd.c
@@ -125,7 +125,7 @@ static void InitBothSidesEnPassantInfo(BoardInfo_t* info) {
     state->halfmoveClock = some_halfmove_clock;
     state->castleSquares[white] = empty_set;
     state->castleSquares[black] = empty_set;
-    state->enPassantSquares = CreateBitboard(2, c3,h6);
+    state->enPassantSquare = CreateBitboard(2, c3,h6);
     state->capturedPiece = none_type;
     state->boardInfo = *info;
 }
@@ -151,7 +151,7 @@ static void InitSideEnPassantExpectedInfo(BoardInfo_t* expectedInfo, GameState_t
 
     GameState_t nextState = ReadDefaultNextGameState(&stack);
     nextState.halfmoveClock = 0;
-    nextState.enPassantSquares = empty_set;
+    nextState.enPassantSquare = empty_set;
     nextState.capturedPiece = pawn;
     *expectedState = nextState;
 }
@@ -169,7 +169,7 @@ static void InitNormalPosition(BoardInfo_t* info) {
 
     GameState_t* state = GetEmptyNextGameState(&stack);
     state->halfmoveClock = some_halfmove_clock;
-    state->enPassantSquares = empty_set;
+    state->enPassantSquare = empty_set;
     state->castleSquares[white] = empty_set;
     state->castleSquares[black] = empty_set;
     state->capturedPiece = none_type;
@@ -204,7 +204,7 @@ static void InitPawnDoublePushExpected(BoardInfo_t* expectedInfo, GameState_t* e
             expectedInfo->knights[black] = CreateBitboard(1, e4);
         });
 
-        state.enPassantSquares = CreateBitboard(1, f3);
+        state.enPassantSquare = CreateBitboard(1, f3);
     } else {
         InitTestInfo(expectedInfo, {
             expectedInfo->kings[white] = CreateBitboard(1, b2);
@@ -215,7 +215,7 @@ static void InitPawnDoublePushExpected(BoardInfo_t* expectedInfo, GameState_t* e
             expectedInfo->knights[black] = CreateBitboard(1, e4);
         });   
 
-        state.enPassantSquares = CreateBitboard(1, d6);
+        state.enPassantSquare = CreateBitboard(1, d6);
     }
 
     *expectedState = state;
@@ -274,7 +274,7 @@ static void InitPromotionCastleBreakPosition(BoardInfo_t* info) {
 
     GameState_t* state = GetEmptyNextGameState(&stack);
     state->halfmoveClock = some_halfmove_clock;
-    state->enPassantSquares = empty_set;
+    state->enPassantSquare = empty_set;
     state->castleSquares[white] = empty_set;
     state->castleSquares[black] = CreateBitboard(1, c8);
     state->boardInfo = *info;
@@ -571,7 +571,7 @@ static bool GenericTestUnmake(BoardInfo_t* startInfo, Move_t move, Color_t moveC
     originalState.halfmoveClock = ReadHalfmoveClock(&stack);
     originalState.castleSquares[white] = ReadCastleSquares(&stack, white);
     originalState.castleSquares[black] = ReadCastleSquares(&stack, black);
-    originalState.enPassantSquares = ReadEnPassant(&stack);
+    originalState.enPassantSquare = ReadEnPassant(&stack);
     originalState.capturedPiece = ReadCapturedPiece(&stack);
 
     MakeMoveTestWrapper(startInfo, &stack, move, moveColor);

--- a/tdd/tests/make_and_unmake_tdd.c
+++ b/tdd/tests/make_and_unmake_tdd.c
@@ -153,6 +153,9 @@ static void InitSideEnPassantExpectedInfo(BoardInfo_t* expectedInfo, GameState_t
     nextState.halfmoveClock = 0;
     nextState.enPassantSquare = empty_set;
     nextState.capturedPiece = pawn;
+    nextState.canEastEP = false;
+    nextState.canWestEP = false;
+
     *expectedState = nextState;
 }
 
@@ -396,6 +399,7 @@ static void ShouldWhiteEnPassant() {
     GameState_t expectedState;
     InitBothSidesEnPassantInfo(&info);
     InitSideEnPassantExpectedInfo(&expectedInfo, &expectedState, white);
+    expectedState.canEastEP = true;
 
     Move_t move;
     InitMove(&move);
@@ -418,6 +422,7 @@ static void ShouldBlackEnPassant() {
     GameState_t expectedState;
     InitBothSidesEnPassantInfo(&info);
     InitSideEnPassantExpectedInfo(&expectedInfo, &expectedState, black);
+    expectedState.canWestEP = true;
 
     Move_t move;
     InitMove(&move);

--- a/tdd/tests/make_and_unmake_tdd.c
+++ b/tdd/tests/make_and_unmake_tdd.c
@@ -203,8 +203,6 @@ static void InitPawnDoublePushExpected(BoardInfo_t* expectedInfo, GameState_t* e
             expectedInfo->pawns[black] = CreateBitboard(1, d7);
             expectedInfo->knights[black] = CreateBitboard(1, e4);
         });
-
-        state.enPassantSquares = CreateBitboard(1, f3);
     } else {
         InitTestInfo(expectedInfo, {
             expectedInfo->kings[white] = CreateBitboard(1, b2);
@@ -214,10 +212,9 @@ static void InitPawnDoublePushExpected(BoardInfo_t* expectedInfo, GameState_t* e
             expectedInfo->pawns[black] = CreateBitboard(1, d5);
             expectedInfo->knights[black] = CreateBitboard(1, e4);
         });   
-
-        state.enPassantSquares = CreateBitboard(1, d6);
     }
 
+    state.enPassantSquares = empty_set;
     *expectedState = state;
 }
 

--- a/tdd/tests/make_and_unmake_tdd.c
+++ b/tdd/tests/make_and_unmake_tdd.c
@@ -203,6 +203,8 @@ static void InitPawnDoublePushExpected(BoardInfo_t* expectedInfo, GameState_t* e
             expectedInfo->pawns[black] = CreateBitboard(1, d7);
             expectedInfo->knights[black] = CreateBitboard(1, e4);
         });
+
+        state.enPassantSquares = CreateBitboard(1, f3);
     } else {
         InitTestInfo(expectedInfo, {
             expectedInfo->kings[white] = CreateBitboard(1, b2);
@@ -212,9 +214,10 @@ static void InitPawnDoublePushExpected(BoardInfo_t* expectedInfo, GameState_t* e
             expectedInfo->pawns[black] = CreateBitboard(1, d5);
             expectedInfo->knights[black] = CreateBitboard(1, e4);
         });   
+
+        state.enPassantSquares = CreateBitboard(1, d6);
     }
 
-    state.enPassantSquares = empty_set;
     *expectedState = state;
 }
 

--- a/tdd/tests/movegen_tdd.c
+++ b/tdd/tests/movegen_tdd.c
@@ -60,36 +60,6 @@ static void InitPinPositionInfo(BoardInfo_t* info) {
     GetEmptyNextGameState(&stack);
 }
 
-// 8/8/PpP1k3/8/4K3/pPp5/8/8
-static void InitDoubleEnPassantPosition(BoardInfo_t* info) {
-    InitTestInfo(info, {
-        info->kings[white] = CreateBitboard(1, e4);
-        info->pawns[white] = CreateBitboard(3, b3,a6,c6);
-
-        info->kings[black] = CreateBitboard(1, e6);
-        info->pawns[black] = CreateBitboard(3, b6,a3,c3);
-    });
-
-    GameState_t* state = GetEmptyNextGameState(&stack);
-    state->enPassantSquare = CreateBitboard(2, b2,b7);
-}
-
-// 1b6/8/2pP4/4KPpr/8/8/8/k7
-static void InitTrickyPinnedEnPassantPostitionInfo(BoardInfo_t* info) {
-    InitTestInfo(info, {
-        info->kings[white] = CreateBitboard(1, e5);
-        info->pawns[white] = CreateBitboard(2, f5,d6);
-
-        info->kings[black] = CreateBitboard(1, a1);
-        info->pawns[black] = CreateBitboard(2, g5,c6);
-        info->bishops[black] = CreateBitboard(1, b8);
-        info->rooks[black] = CreateBitboard(1, h5);
-    });
-
-    GameState_t* state = GetEmptyNextGameState(&stack);
-    state->enPassantSquare = CreateBitboard(2, g6,c7);
-}
-
 // TESTS
 static void ShouldCorrectlyEvaluateCapturesInPosWithPins() {
     TestSetup();
@@ -114,45 +84,6 @@ static void ShouldCorrectlyEvaluateCapturesInPosWithPins() {
         (CountPieceMoves(knight, moveList, &info) == expectedNumKnightsCaptures) &&
         (CountPieceMoves(queen, moveList, &info) == expectedNumQueenCaptures) &&
         moveList.maxIndex == 7;
-
-    PrintResults(success);
-}
-
-static void ShouldCorrectlyEvaluateDoubleEnPassant() {
-    TestSetup();
-    BoardInfo_t info;
-    InitDoubleEnPassantPosition(&info);
-
-    int expectedNumPawnWhiteCaptures = 2;
-    int expectedNumPawnBlackCaptures = 2;
-
-    MoveList_t wMoveList;
-    CapturesMovegenTestWrapper(&wMoveList, &info, &stack, white);
-
-    MoveList_t bMoveList;
-    CapturesMovegenTestWrapper(&bMoveList, &info, &stack, black);
-
-    bool success = 
-        (CountPieceMoves(pawn, wMoveList, &info) == expectedNumPawnWhiteCaptures) &&
-        (CountPieceMoves(pawn, bMoveList, &info) == expectedNumPawnBlackCaptures) &&
-        (wMoveList.maxIndex == 1) && (bMoveList.maxIndex == 1);
-
-    PrintResults(success);
-}
-
-static void ShouldCorrectlyEvaluatePinnedEnPassant() {
-    TestSetup();
-    BoardInfo_t info;
-    InitTrickyPinnedEnPassantPostitionInfo(&info);
-
-    int expectedNumPawnWhiteCaptures = 1;
-
-    MoveList_t moveList;
-    CapturesMovegenTestWrapper(&moveList, &info, &stack, white);
-
-    bool success = 
-        (CountPieceMoves(pawn, moveList, &info) == expectedNumPawnWhiteCaptures) &&
-        moveList.maxIndex == 0;
 
     PrintResults(success);
 }
@@ -194,7 +125,5 @@ static void ShouldCorrectlyEvaluateInPosWithPins() {
 
 void MovegenTDDRunner() {
     ShouldCorrectlyEvaluateCapturesInPosWithPins();
-    ShouldCorrectlyEvaluateDoubleEnPassant();
-    ShouldCorrectlyEvaluatePinnedEnPassant();
     ShouldCorrectlyEvaluateInPosWithPins();
 }

--- a/tdd/tests/movegen_tdd.c
+++ b/tdd/tests/movegen_tdd.c
@@ -71,7 +71,7 @@ static void InitDoubleEnPassantPosition(BoardInfo_t* info) {
     });
 
     GameState_t* state = GetEmptyNextGameState(&stack);
-    state->enPassantSquares = CreateBitboard(2, b2,b7);
+    state->enPassantSquare = CreateBitboard(2, b2,b7);
 }
 
 // 1b6/8/2pP4/4KPpr/8/8/8/k7
@@ -87,7 +87,7 @@ static void InitTrickyPinnedEnPassantPostitionInfo(BoardInfo_t* info) {
     });
 
     GameState_t* state = GetEmptyNextGameState(&stack);
-    state->enPassantSquares = CreateBitboard(2, g6,c7);
+    state->enPassantSquare = CreateBitboard(2, g6,c7);
 }
 
 // TESTS


### PR DESCRIPTION
Really gross way of doing this maybe, but what I did was moved the check for valid EP square to `MakeMove` and `InterpretFEN` rather than checking in Movegen.